### PR TITLE
Fix rg PCRE2 error for .c files

### DIFF
--- a/autoload/search.vim
+++ b/autoload/search.vim
@@ -3,7 +3,7 @@
 let s:regexp_keyword_word = 'KEYWORD'
 let s:engines             = ['rg', 'ag']
 
-let s:rg_base_cmd = "rg -n --auto-hybrid-regex --json"
+let s:rg_base_cmd = "rg -n --auto-hybrid-regex --json --no-pcre2-unicode"
 let s:ag_base_cmd = "ag --nogroup --noheading"
 
 let s:rg_filetype_convertion_map = {


### PR DESCRIPTION
Any jump would not work on c files because of some PCRE2 error inside ripgrep. 